### PR TITLE
Refactor AI judge for independent criteria evaluation

### DIFF
--- a/examples/basic_examples/evals/poem_agent_suite.py
+++ b/examples/basic_examples/evals/poem_agent_suite.py
@@ -5,14 +5,7 @@ poem_agent_test_suite = [
     },
 ]
 
-poem_agent_criteria = """
-**1. Line Count**: The poem must be exactly 50 lines long. Count each line break as one line, excluding empty lines or any `<think>` tags or lines.
-
-**2. Poem Structure**: The output must be a poem, not prose or other text formats. This means:
-   - It should have poetic elements such as rhythm, meter, or free verse structure
-   - It should use poetic language with imagery, metaphors, or other literary devices
-   - It should not be written as paragraphs or continuous prose
-   - It should have clear line breaks that create poetic structure
-
-If **any** of these criteria are violated, the test fails.
-"""
+poem_agent_criteria = [
+    "The poem is exactly 50 lines long; count each line break as one line, excluding empty lines and any <think> tags or lines.",
+    "The output is a poem (not prose) with poetic elements (e.g., rhythm, meter, or free verse), poetic language (imagery, metaphors, or other literary devices), and clear line breaks that create poetic structure.",
+]

--- a/examples/basic_examples/evaluation/evals/simple_greeting_suite.py
+++ b/examples/basic_examples/evaluation/evals/simple_greeting_suite.py
@@ -31,15 +31,11 @@ simple_greeting_test_suite = [
     },
 ]
 
-simple_greeting_criteria = """
-**1. Name Inclusion**: The greeting must include the exact name provided in the prompt.
-**2. Tone Appropriateness**: 
-    - Formal titles (Dr., Mr., Ms., Professor) should receive formal greetings
-    - First names should receive informal, friendly greetings
-**3. Length**: Greeting should be 1-2 sentences (not too short, not too long).
-**4. Friendliness**: Greeting should be welcoming and positive.
-**5. No Extra Content**: Should not include explanations, markdown, or extra text beyond the greeting.
-**6. Keyword Presence**: Must contain expected keywords based on the test case.
-
-If **any** rule above is violated, the test fails.
-""" 
+simple_greeting_criteria = [
+    "The greeting includes the exact name provided in the prompt.",
+    "Tone appropriateness: formal titles (Dr., Mr., Ms., Professor) receive formal greetings; first names receive informal, friendly greetings.",
+    "Length: the greeting is 1–2 sentences.",
+    "Friendliness: the greeting is welcoming and positive.",
+    "No extra content: no explanations, markdown, or any text beyond the greeting.",
+    "Keyword presence: contains expected keywords based on the test case.",
+] 

--- a/examples/deep_research/clarifier/evals/outline_based_clarification_suite.py
+++ b/examples/deep_research/clarifier/evals/outline_based_clarification_suite.py
@@ -84,13 +84,10 @@ These developments reflect Nebraska's commitment to fiscal responsibility and ec
     },
 ]
 
-outline_based_clarification_criteria = """
-**1. Question Count**: The 'questions' list in the JSON output must contain between 1 and 4 questions.
-**2. Relevance, Clarity, and Form**:
-    a. For each question:
-        i. It must be relevant to the prompt and clearly phrased. A question is relevant if it addresses an aspect of the prompt that could benefit from clarification to narrow the research scope.
-        ii. It must be a CLARIFYING question. As a practical heuristic, a valid clarifying question is typically closed-ended and begins with phrases like "Are you…", "Do you…", "Would you…", "Which of these…", "Should the focus be…", etc.
-        iii. Wh-questions that begin with "What", "How", "Why", "When", "Where" are generally research questions and must be rejected. However, wh-questions are acceptable ONLY when they clearly ask for user preferences or choices (e.g., "What level of detail do you want?", "Which specific aspects interest you most?", "How technical should the explanation be?").
-        iv. Questions must be useful for narrowing research scope and avoid redundancy across multiple questions.
-    b. If **any** question fails 2.a.ii, 2.a.iii, or 2.a.iv then the entire test fails.
-"""
+outline_based_clarification_criteria = [
+    "The 'questions' list in the JSON output contains between 1 and 4 questions.",
+    "For each question: it is relevant to the prompt and clearly phrased.",
+    "For each question: it is a clarifying question (typically closed-ended; begins with phrases like 'Are you', 'Do you', 'Would you', 'Which of these', 'Should the focus be').",
+    "Wh-questions ('What', 'How', 'Why', 'When', 'Where') are not allowed unless they clearly ask for user preferences or choices (e.g., 'What level of detail do you want?', 'Which specific aspects interest you most?', 'How technical should the explanation be?').",
+    "Questions are useful for narrowing research scope and avoid redundancy across multiple questions.",
+]

--- a/examples/deep_research/clarifier/evals/self_critique_query_reviser_suite.py
+++ b/examples/deep_research/clarifier/evals/self_critique_query_reviser_suite.py
@@ -167,16 +167,13 @@ self_critique_query_reviser_test_suite = [
     },
 ]
 
-self_critique_query_reviser_criteria = """
-**1. Structure**: The agent output must be a JSON object containing **exactly** three keys: `initial_draft_query`, `critique`, and `final_revised_query`.
-**2. Non-empty Strings**: Each of these three fields must be a non-empty string.
-**3. Draft vs Final**: Ordinarily, `final_revised_query` **should differ** from `initial_draft_query`, reflecting improvements raised in the `critique`.  
-    • *Exception*: If the two are identical, the `critique` should provide some justification as to why no change was necessary.
-**4. Faithfulness to User Intent**: The `final_revised_query` must accurately capture the **substantive intent** expressed in BOTH the `original_topic` and the `user_clarification_answer`. It should incorporate all meaningful constraints (scope, time frame, demographic, tone, structure, etc.) without adding or omitting material information.
-**5. Avoiding Bias from Questions**: The `final_revised_query` should not be unduly influenced by wording or suggestions in `clarifying_questions_asked` that were **not** accepted or acknowledged by the user. Introducing new angles the user did not endorse causes failure.
-**6. Respecting Unanswered Questions**: A clarifying question that the **user chose not to answer** should leave **no trace** in the `final_revised_query`. Lack of an answer does **not** license the agent to invent content *or* to forcibly exclude a topic; simply omit that dimension unless it is implicitly covered by the user's clarification.
-**7. Clarity & Conciseness**: The query must be clear, unambiguous, and concise (single sentence is ideal). Excessive verbosity, redundant qualifiers, or unclear phrasing fails the test.
-**8. Completeness**: The query must integrate all *salient* details from the `user_clarification_answer` so that it is ready for research without needing further clarification.
-
-If **any** rule above is violated, the test fails.
-"""
+self_critique_query_reviser_criteria = [
+    "The agent output is a JSON object containing exactly three keys: 'initial_draft_query', 'critique', and 'final_revised_query'.",
+    "Each of 'initial_draft_query', 'critique', and 'final_revised_query' is a non-empty string.",
+    "Ordinarily, 'final_revised_query' differs from 'initial_draft_query', reflecting improvements raised in the critique; if identical, the critique justifies why no change was necessary.",
+    "The 'final_revised_query' accurately captures the substantive intent expressed in BOTH 'original_topic' and 'user_clarification_answer', incorporating all meaningful constraints without adding or omitting material information.",
+    "The 'final_revised_query' is not unduly influenced by wording or suggestions in 'clarifying_questions_asked' that were not accepted or acknowledged by the user.",
+    "Unanswered clarifying questions leave no trace in the 'final_revised_query'.",
+    "The 'final_revised_query' is clear, unambiguous, and concise (ideally a single sentence).",
+    "The 'final_revised_query' integrates all salient details from 'user_clarification_answer' so it is ready for research without further clarification.",
+]

--- a/examples/deep_research/clarifier/evals/topic_assessor_suite.py
+++ b/examples/deep_research/clarifier/evals/topic_assessor_suite.py
@@ -48,6 +48,6 @@ topic_assessor_test_suite = [
     },
 ]
 
-topic_assessor_criteria = """
-**Assessment Accuracy**: The 'assessment' field in the JSON output must exactly match the `expected_assessment` from the test case details.
-"""
+topic_assessor_criteria = [
+    "The 'assessment' field in the JSON output exactly matches the 'expected_assessment' from the test case details.",
+]

--- a/examples/deep_research/researcher/evals/question_generator_suite.py
+++ b/examples/deep_research/researcher/evals/question_generator_suite.py
@@ -41,13 +41,9 @@ question_generator_test_suite = [
     },
 ]
 
-question_generator_criteria = """
-**1. JSON Structure**: The output must be a valid JSON object with exactly one key 'questions' containing a list of strings.
-**2. Question Count**: The 'questions' list must contain exactly 3 questions.
-**3. Question Quality**: Each question must be:
-   - Relevant to the research topic provided in the prompt
-   - Clear and specific enough to guide focused research
-   - Different from each other to ensure comprehensive coverage
-   - Phrased as answerable research questions that would help gather information about the topic
-**4. No Extra Fields**: The JSON output should contain only the 'questions' field, no other fields like 'state_name' or metadata.
-"""
+question_generator_criteria = [
+    "The output is a valid JSON object with exactly one key 'questions' containing a list of strings.",
+    "The 'questions' list contains exactly 3 questions.",
+    "Each question is relevant to the research topic, clear and specific, different from the others, and phrased as an answerable research question.",
+    "No extra fields are present beyond 'questions'.",
+]

--- a/examples/deep_research/researcher/evals/reflection_agent_suite.py
+++ b/examples/deep_research/researcher/evals/reflection_agent_suite.py
@@ -249,23 +249,10 @@ Max iterations: 2""",
     },
 ]
 
-reflection_agent_criteria = """
-**1. JSON Structure**: The output must be a valid JSON object with exactly two fields: 'additional_questions' (list) and 'reasoning' (string). No other fields like 'state_name' should be present.
-
-**2. Additional Questions Logic**: The reflection agent must correctly determine when to continue or stop research:
-   - If the research should continue, the 'additional_questions' list must contain between 1 and 3 non-empty research questions.
-   - If the research should stop, the 'additional_questions' list must be empty.
-   - Expected behavior is indicated by the 'expected_additional_questions_empty' field in each test case.
-
-**3. Question Quality**: When 'additional_questions' is non-empty, the questions must be:
-   - Specific and focused research questions that address knowledge gaps
-   - Different from existing questions that were already researched
-   - Relevant to exploring deeper aspects of the research topic
-
-**4. Reasoning Quality**: The 'reasoning' field must be a non-empty string that logically justifies the decision, considering factors like:
-   - Current iteration vs max iterations
-   - Scope and complexity of the research topic
-   - Adequacy of gathered knowledge relative to the topic's requirements
-   - Identification of specific knowledge gaps
-
-**5. Complex Topic Assessment**: For complex, multi-faceted topics like "the first six months of a worldwide pandemic" with minimal research completed (current_iteration much less than max_iterations), the agent should recognize that more research is needed and generate additional questions unless max_iterations is reached."""
+reflection_agent_criteria = [
+    "The output is a valid JSON object with exactly two fields: 'additional_questions' (list) and 'reasoning' (string); no other fields are present.",
+    "Decision logic: If research should continue, 'additional_questions' contains 1 to 3 non-empty research questions; if research should stop, 'additional_questions' is empty, aligned with 'expected_additional_questions_empty' in the test case.",
+    "When present, 'additional_questions' are specific, address knowledge gaps, differ from existing researched questions, and are relevant to deeper exploration of the topic.",
+    "'reasoning' is a non-empty string that logically justifies the decision, considering current vs max iterations, topic complexity, adequacy of gathered knowledge, and identified knowledge gaps.",
+    "For complex, multi-faceted topics with minimal research completed (current_iteration much less than max_iterations), the agent recognizes that more research is needed and generates additional questions unless max_iterations is reached.",
+]

--- a/examples/deep_research/summarizer/evals/initial_outline_generator_suite.py
+++ b/examples/deep_research/summarizer/evals/initial_outline_generator_suite.py
@@ -41,29 +41,12 @@ initial_outline_generator_test_suite = [
     },
 ]
 
-initial_outline_generator_criteria = """
-**1. JSON Structure**: The output must be a valid JSON object with exactly two keys: 'state_name' and 'outline'.
-
-**2. State Name**: The 'state_name' field must be exactly "ready_for_critique".
-
-**3. Outline Count**: The 'outline' list must contain between 3 and 8 sections.
-
-**4. Section Quality**: Each section must be:
-   - A clear, descriptive title that relates to the research topic
-   - Specific enough to guide content development
-   - Different from other sections (no redundancy)
-   - Appropriate for a comprehensive research report
-
-**5. Logical Structure**: The outline must demonstrate logical flow:
-   - Should typically start with an introduction or background section
-   - Include substantive sections covering main findings/themes
-   - Should typically end with a conclusion or summary section
-   - Sections should build upon each other logically
-
-**6. Comprehensiveness**: The outline must adequately cover the research topic:
-   - Address the main aspects mentioned in the gathered knowledge
-   - Provide sufficient breadth to cover the topic comprehensively
-   - Not miss obvious major themes from the research data
-
-**7. Professionalism**: Section titles must be professional and appropriate for an academic or business report format.
-"""
+initial_outline_generator_criteria = [
+    "The output is a valid JSON object with exactly two keys: 'state_name' and 'outline'.",
+    "The 'state_name' field is exactly 'ready_for_critique'.",
+    "The 'outline' list contains between 3 and 8 sections.",
+    "Each section title is clear, descriptive, specific enough to guide content development, different from other sections, and appropriate for a comprehensive report.",
+    "The outline demonstrates logical flow (typically introduction → substantive sections → conclusion) with sections that build upon each other logically.",
+    "The outline adequately covers the research topic, addresses main aspects from the gathered knowledge, provides sufficient breadth, and does not miss obvious major themes.",
+    "Section titles are professional and appropriate for an academic or business report format.",
+]

--- a/examples/deep_research/summarizer/evals/outline_critiquer_suite.py
+++ b/examples/deep_research/summarizer/evals/outline_critiquer_suite.py
@@ -45,38 +45,14 @@ outline_critiquer_test_suite = [
     },
 ]
 
-outline_critiquer_criteria = """
-**1. JSON Structure**: The output must be a valid JSON object with exactly two keys: 'state_name' and 'revised_outline'.
-
-**2. State Name**: The 'state_name' field must be exactly "ready_for_expansion".
-
-**3. Section Count**: The 'revised_outline' list must contain between 3 and 8 sections.
-
-**4. Improvement Over Initial**: The revised outline must show clear improvement over the initial outline:
-   - Eliminate redundancy (merge similar sections)
-   - Fix unclear or vague section titles
-   - Add missing sections that are important for the topic
-   - Improve logical flow and structure
-
-**5. User Requirement Adherence**: If the user has specified structural requirements (e.g., "three-section report"), the revised outline MUST honor those requirements exactly.
-
-**6. Comprehensive Coverage**: The outline must adequately address all major themes present in the gathered knowledge:
-   - No significant aspects from the research should be missing
-   - All main findings should be addressable within the outline structure
-
-**7. Logical Flow**: The revised outline must demonstrate clear logical progression:
-   - Sections should build upon each other
-   - Introduction → main content → conclusion structure when appropriate
-   - No illogical ordering of sections
-
-**8. Professional Quality**: Section titles must be:
-   - Clear and descriptive
-   - Professional and appropriate for academic/business reports
-   - Specific enough to guide content development
-   - Free of redundancy or overlap
-
-**9. Handling Edge Cases**: The agent must handle special cases appropriately:
-   - Empty initial outlines should result in a complete new outline
-   - Severely flawed outlines should be substantially restructured
-   - Good outlines should receive minor improvements or be kept largely intact
-"""
+outline_critiquer_criteria = [
+    "The output is a valid JSON object with exactly two keys: 'state_name' and 'revised_outline'.",
+    "The 'state_name' field is exactly 'ready_for_expansion'.",
+    "The 'revised_outline' list contains between 3 and 8 sections.",
+    "The revised outline shows clear improvement over the initial outline by eliminating redundancy, fixing unclear or vague titles, adding missing important sections, and improving logical flow and structure.",
+    "If the user specifies structural requirements (e.g., 'three-section report'), the revised outline honors those requirements exactly.",
+    "The outline adequately addresses major themes present in the gathered knowledge with no significant omissions and all main findings addressable within the structure.",
+    "The revised outline demonstrates clear logical progression (sections build upon each other; appropriate introduction → main content → conclusion ordering; no illogical ordering).",
+    "Section titles are clear, descriptive, professional, specific, and free of redundancy or overlap.",
+    "Edge cases are handled appropriately: empty initial outlines yield a complete new outline; severely flawed outlines are substantially restructured; good outlines receive minor improvements or are kept largely intact.",
+]

--- a/examples/standalone/evals/lean_startup_experiment_generator_suite.py
+++ b/examples/standalone/evals/lean_startup_experiment_generator_suite.py
@@ -5,28 +5,12 @@ lean_startup_experiment_generator_test_suite = [
     }
 ]
 
-lean_startup_experiment_generator_criteria = """
-Goal: Validate the subagent outputs exactly three SMART experiments suitable for a 14-day window.
-
-PASS only if ALL conditions are met:
-
-1) Count & Presence
-   - Output contains key `experiments` with exactly 3 items.
-
-2) Specific & Hypothesis-linked
-   - Each experiment has a clear `objective` stating the learning and implicitly ties to demand/problem validation.
-
-3) Measurable
-   - Each experiment includes a `metric` and `success_criteria` with explicit numeric thresholds (counts, percentages, or rates). Qualitative-only criteria are not acceptable.
-
-4) Achievable & Time-bound
-   - Each experiment has `timeline_days` between 1 and 14.
-   - Scope appears feasible for a solo founder with low cost; presence of `estimated_cost` and minimal `required_assets` supports practicality.
-
-5) Relevant
-   - At least one experiment tests demand directly (e.g., smoke test, pre-order), and one probes problem severity (e.g., interviews with a numeric bar for severe pain reports).
-
-Fail if: fewer/greater than 3 experiments; any missing metrics/thresholds; timelines outside 1–14; or all three experiments fail to address demand/problem validation.
-"""
+lean_startup_experiment_generator_criteria = [
+    "Output contains key 'experiments' with exactly 3 items.",
+    "Each experiment includes a clear 'objective' stating the learning and implicitly ties to demand/problem validation.",
+    "Each experiment specifies a 'metric' and 'success_criteria' with explicit numeric thresholds (counts, percentages, or rates); qualitative-only criteria are unacceptable.",
+    "Each experiment includes 'timeline_days' between 1 and 14 and is feasible for a solo founder with low cost; presence of 'estimated_cost' and minimal 'required_assets' supports practicality.",
+    "Collectively, at least one experiment tests demand directly (e.g., smoke test, pre-order) and at least one probes problem severity (e.g., interviews with a numeric bar for severe pain reports).",
+]
 
 

--- a/examples/standalone/evals/lean_startup_validation_suite.py
+++ b/examples/standalone/evals/lean_startup_validation_suite.py
@@ -5,40 +5,14 @@ lean_startup_validation_test_suite = [
     }
 ]
 
-lean_startup_validation_criteria = """
-Goal: Verify the agent outputs a Lean Startup validation plan whose experiments include SMART measures (Specific, Measurable, Achievable, Relevant, Time-bound).
-
-PASS only if ALL conditions below are met:
-
-1) Experiments Presence & Count
-   - The output contains `validation_plan.experiments` as a non-empty list.
-   - There are at least 2 distinct experiments proposed.
-
-2) Specific
-   - Each experiment has a clear `objective` that states exactly what learning it targets (e.g., validates a specific customer behavior or value proposition element), not vague wording.
-   - The `objective` should be traceable to a particular hypothesis or riskiest assumption (directly referenced or clearly implied).
-
-3) Measurable
-   - Each experiment specifies a `metric` and a `success_criteria` with an explicit numeric threshold or unambiguous comparator (e.g., ">= 15 signups", "conversion >= 5%", "at least 8/10 interviewees report X").
-   - Thresholds must be concrete (numbers, percentages, counts, or rates). Qualitative-only criteria (e.g., "good feedback") are insufficient.
-
-4) Achievable
-   - Each experiment includes a short timeline and cost that make it realistically executable by a solo founder within ~14 days and low budget.
-   - Evidence in the plan (e.g., `timeline_days` ≤ 14, minimal `required_assets`, modest `estimated_cost`) supports practicality.
-
-5) Relevant
-   - Experiments collectively focus on validating the top 1–2 riskiest assumptions first (e.g., real demand, willingness to pay, problem severity), not low-risk implementation details.
-   - At least one experiment directly tests demand (e.g., smoke test, pre-order/payment intent, strong sign-up signal) or strong problem validation (e.g., interviews with clear pain signals).
-
-6) Time-bound
-   - Each experiment includes `timeline_days` with a positive integer and a short duration (ideally ≤ 14 days).
-
-7) Internal Consistency
-   - `success_criteria` aligns with the specified `metric` and the experiment's `objective`.
-   - The plan’s `go_pivot_kill_criteria` are compatible with experiment thresholds (no contradictions).
-
-Failure cases:
-   - Fewer than 2 experiments; missing metrics; thresholds not numeric; missing or unrealistic timelines; objectives not tied to hypotheses; experiments unrelated to top risks; or contradictory thresholds.
-"""
+lean_startup_validation_criteria = [
+    "The output contains 'validation_plan.experiments' as a non-empty list with at least 2 distinct experiments.",
+    "Each experiment has a clear 'objective' that states exactly what learning it targets and is traceable to a specific hypothesis or riskiest assumption.",
+    "Each experiment specifies a 'metric' and a 'success_criteria' with an explicit numeric threshold or unambiguous comparator (e.g., '>= 15 signups', 'conversion >= 5%', 'at least 8/10 report X').",
+    "Each experiment includes a short timeline and cost that make it realistically executable by a solo founder within ~14 days and low budget (evidence: 'timeline_days' ≤ 14, minimal 'required_assets', modest 'estimated_cost').",
+    "Experiments collectively focus on validating the top 1–2 riskiest assumptions first, with at least one experiment directly testing demand or strong problem validation.",
+    "Each experiment includes 'timeline_days' as a positive integer with a short duration (ideally ≤ 14 days).",
+    "Internal consistency: 'success_criteria' aligns with the 'metric' and the experiment's 'objective', and plan-level criteria do not contradict experiment thresholds.",
+]
 
 

--- a/framework/evaluation.py
+++ b/framework/evaluation.py
@@ -94,7 +94,7 @@ Convention:
 2. A sibling directory named `evals/` sits next to that YAML. Python files inside
    it define one or more test suites.
 3. A test-suite file must expose exactly one list whose variable name ends with
-   `_test_suite` and exactly one string whose variable name ends with `_criteria`.
+   `_test_suite` and exactly one list/tuple of strings whose variable name ends with `_criteria`.
 
 The framework discovers these variables reflectively and evaluates the agent
 against each case using an AI-judge pattern.
@@ -272,7 +272,9 @@ async def evaluate_agent_against_suite(
         # Judge per criterion independently
         criteria_list = [str(c).strip() for c in (evaluation_criteria or []) if str(c).strip()]
         if not criteria_list:
-            criteria_list = [""]
+            case_rows.append({"id": test_id, "result": "FAIL", "criteria": "0/0"})
+            logger.warning("[FAIL] %s – empty criteria list provided; cannot judge.", test_id)
+            continue
 
         per_criterion_results: List[EvaluationResult] = []
 

--- a/framework/evaluation.py
+++ b/framework/evaluation.py
@@ -476,8 +476,8 @@ def _load_eval_module(yaml_path: str) -> ModuleType:
 def _extract_suite_and_criteria(module: ModuleType) -> Tuple[List[Dict[str, Any]], Any]:
     """Extract the test suite list and criteria object from the module via naming convention.
 
-    The criteria may be a str, list/tuple of strings, or a dict with
-    optional 'preamble', 'criteria' (list/str), and 'closing'.
+    The criteria must be a list/tuple of strings, or a dict with
+    optional 'preamble' (str), 'criteria' (list/str), and 'closing' (str).
     """
 
     test_suite: Optional[List[Dict[str, Any]]] = None
@@ -486,13 +486,13 @@ def _extract_suite_and_criteria(module: ModuleType) -> Tuple[List[Dict[str, Any]
     for attr_name, attr_val in vars(module).items():
         if attr_name.endswith("_test_suite") and isinstance(attr_val, list):
             test_suite = attr_val
-        elif attr_name.endswith("_criteria") and isinstance(attr_val, (str, list, tuple, dict)):
+        elif attr_name.endswith("_criteria") and isinstance(attr_val, (list, tuple, dict)):
             criteria = attr_val
 
     if test_suite is None or criteria is None:
         raise AttributeError(
             "Evaluation module must define variables ending with `_test_suite` (list) "
-            "and `_criteria` (str | list | dict)."
+            "and `_criteria` (list | tuple | dict)."
         )
 
     return test_suite, criteria


### PR DESCRIPTION
Enable multi-criteria AI judging by evaluating each criterion independently to prevent judgment influence.

The original judge evaluated all criteria in a single prompt, which could lead to the judge's assessment of an early criterion affecting its judgment of a later one. By splitting the criteria and running the judge for each one separately, we ensure that each criterion is evaluated in isolation, leading to more robust and unbiased results.

---
<a href="https://cursor.com/background-agent?bcId=bc-be2d9393-04cf-425e-bb68-769cc3c77ed1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be2d9393-04cf-425e-bb68-769cc3c77ed1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

